### PR TITLE
Added filter to NAT lookup

### DIFF
--- a/v2/aws_ec2_nat_gateway_id_from_eip.py
+++ b/v2/aws_ec2_nat_gateway_id_from_eip.py
@@ -31,7 +31,8 @@ class LookupModule(LookupBase):
             ec2_client = session.client('ec2')
         except botocore.exceptions.NoRegionError:
             raise AnsibleError("AWS region not specified.")
-        result = ec2_client.describe_nat_gateways()
+        filter = [{'Name': 'state','Values': ['available']}]
+        result = ec2_client.describe_nat_gateways(Filter=filter)
         nat_gateways = result.get('NatGateways')
         if nat_gateways:
             for nat_gateway in nat_gateways:


### PR DESCRIPTION
DescribeNatGateway always returns a list, if the NAT gateway is deleted and if we run the lookup just after that, it returns older deleted Nat gateway id. Adding the state filter solves the problem.
