### PR TITLE
Extra changes for running instances

### DIFF
--- a/aws_ec2_instance_id_from_name.py
+++ b/aws_ec2_instance_id_from_name.py
@@ -30,7 +30,8 @@ class LookupModule(LookupBase):
         except botocore.exception.NoRegionError:
             raise AnsibleError("AWS region not specified")
 
-        instance_filter=[{'Name':'tag:Name', 'Values': [instance_name]}]
+        instance_filter=[{'Name':'tag:Name', 'Values': [instance_name]},
+                         {'Name': 'instance-state-name', 'Values': ['running']}]
 
         result=ec2_client.describe_instances(Filters=instance_filter)
 

--- a/aws_ec2_instance_private_ip_from_name.py
+++ b/aws_ec2_instance_private_ip_from_name.py
@@ -34,7 +34,8 @@ class LookupModule(LookupBase):
         except botocore.exceptions.NoRegionError:
             raise AnsibleError("AWS region must be specified")
 
-        instance_filter=[{'Name': 'tag:Name', 'Values': [instance_name]}]
+        instance_filter=[{'Name': 'tag:Name', 'Values': [instance_name]},
+                         {'Name': 'instance-state-name', 'Values': ['running']}]
 
         result=ec2_client.describe_instances(Filters=instance_filter)
 

--- a/aws_ec2_instance_public_ip_from_name.py
+++ b/aws_ec2_instance_public_ip_from_name.py
@@ -7,6 +7,7 @@ Example Usage:
 {{ lookup('aws_ec2_instance_public_ip_from_name', ('eu-west-1', 'server1') }}
 """
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 import os
@@ -21,25 +22,27 @@ try:
 except ImportError:
     raise AnsibleError("aws_ec2_instance_public_ip_from_name lookup cannot be run without boto3 installed")
 
+
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
         region = terms[0][0]
         instance_name = terms[0][1]
 
-        session=boto3.session.Session(region_name=region)
+        session = boto3.session.Session(region_name=region)
 
         try:
-            ec2_client=session.client('ec2')
+            ec2_client = session.client('ec2')
         except botocore.exceptions.NoRegionError:
             raise AnsibleError("AWS region must be specified")
 
-        instance_filter=[{'Name': 'tag:Name', 'Values': [instance_name]}]
+        instance_filter = [{'Name': 'tag:Name', 'Values': [instance_name]},
+                           {'Name': 'instance-state-name', 'Values': ['running']}]
 
-        result=ec2_client.describe_instances(Filters=instance_filter)
+        result = ec2_client.describe_instances(Filters=instance_filter)
 
-        result=result.get('Reservations')
+        result = result.get('Reservations')
 
-        if result and result[0].get('Instances') and result[0].get('Instances')[0].get('PublicIpAddress'):
+        if result and result[0].get('Instances')[0].get('PublicIpAddress'):
             return [result[0].get('Instances')[0].get('PublicIpAddress').encode('utf-8')]
         return None

--- a/aws_ec2_instance_status_from_name.py
+++ b/aws_ec2_instance_status_from_name.py
@@ -43,7 +43,7 @@ class LookupModule(LookupBase):
         result = ec2_client.describe_instances(Filters=instance_filter)
         reservations = result.get('Reservations')
 
-        if reservations:
+        if reservations and reservations[0].get('Instances')[0].get('State').get('Name'):
             return [reservations[0].get('Instances')[0].get('State').get('Name').encode('utf-8')]
         return None
 


### PR DESCRIPTION
When retrieving IP addresses from instances, no consideration was taken regarding the instance's state. As a result, retrieval of the IP address of a terminated instance would be attempted and cause an exception/incorrect return data.